### PR TITLE
Switch Buster to use archive.debian.org

### DIFF
--- a/salsa-ci.yml
+++ b/salsa-ci.yml
@@ -773,7 +773,7 @@ stages:
     - |
       if [ "$VENDOR" = "debian" ]; then \
         case "$RELEASE" in
-          stretch*)
+          buster*|stretch*)
             MIRROR=${SALSA_CI_DEBIAN_ARCHIVE_MIRROR}
             ;;
           *)


### PR DESCRIPTION
Buster is currently in the progress of being archived: https://lists.debian.org/debian-devel-announce/2024/03/msg00003.html

We already noticed Buster armel only available on archive.debian.org. Thus the mainline Salsa-CI has been failing job
'images-prod-arm: [base, arm32v5, buster]' on:

    Err:4 http://deb.debian.org/debian buster/main armel Packages
    404  Not Found [IP: 151.101.162.132 80]
    Err:5 http://deb.debian.org/debian buster-updates/main armel Packages
    404  Not Found [IP: 151.101.162.132 80]

Switch Buster to use the archive.debian.org mirror which seems to have armhf along with all other architectures.